### PR TITLE
Añadir título y tabla de resultados en la página principal

### DIFF
--- a/frontend/estilos-css/estilos-principal.css
+++ b/frontend/estilos-css/estilos-principal.css
@@ -1,3 +1,8 @@
+:root {
+    --bulma-link-h: 0deg;
+    --bulma-link-l: 40%;
+  }
+
 .contenedor__titulo{
     display: flex;
     align-items: center;
@@ -29,4 +34,21 @@
         transform: translateX(0);    
         opacity: 1;                  
     }
+}
+
+.resultados{
+    margin: 3rem;
+    margin-top: 1rem;
+    padding: 2rem;
+    font-family: ui-sans-serif,system-ui,sans-serif;
+}
+
+.resultados h2{
+    font-size: 4rem;
+    font-style: oblique;
+    font-weight: bold;
+}
+
+.table th{
+    background-color: #b4c2bd;
 }

--- a/frontend/pagina-principal.html
+++ b/frontend/pagina-principal.html
@@ -57,6 +57,90 @@
                 </div>
             </div>
           </section>
+          <div class="resultados">
+            <h2>Resultados 2024</h2>
+            <div class="box">
+              <div class="tabs">
+                <ul>
+                  <li class="is-active" data-target="tabla_carreras"><a>Carreras</a></li>
+                  <li data-target="tabla_pilotos"><a>Pilotos</a></li>
+                  <li data-target="tabla_escuderias"><a>Escuderías</a></li>
+                </ul>
+              </div>
+              <table class="table is-fullwidth is-hoverable active" id="tabla_carreras">
+                <thead>
+                  <tr>
+                    <th>Carrera</th>
+                    <th>Fecha</th>
+                    <th>Ganador</th>
+                    <th>Escuderia</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>nombre_carrera</td>
+                    <td>fecha</td>
+                    <td>nombre_ganador</td>
+                    <td>nombre_escuderia</td>
+                  </tr>
+                  <tr>
+                    <td>GP Las Vegas</td>
+                    <td>23 Nov 2024</td>
+                    <td>George Russell</td>
+                    <td>Mercedes</td>
+                  </tr>
+                </tbody>
+              </table>
+              <table class="table is-hoverable is-fullwidth" id="tabla_pilotos">
+                <thead>
+                  <tr>
+                    <th>Posicion</th>
+                    <th>Nº</th>
+                    <th>Piloto</th>
+                    <th>Escuderia</th>
+                    <th>Puntos</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>posicion</td>
+                    <td>numero</td>
+                    <td>nombre_piloto</td>
+                    <td>nombre_escuderia</td>
+                    <td>puntos</td>
+                  </tr>
+                  <tr>
+                    <td>1</td>
+                    <td>23</td>
+                    <td>George Russell</td>
+                    <td>Mercedes</td>
+                    <td>54</td>
+                  </tr>
+                </tbody>
+              </table>
+              <table class="table is-hoverable is-fullwidth" id="tabla_escuderias">
+                <thead>
+                  <tr>
+                    <th>Posicion</th>
+                    <th>Escuderia</th>
+                    <th>Puntos</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>posicion</td>
+                    <td>nombre_escuderia</td>
+                    <td>puntos</td>
+                  </tr>
+                  <tr>
+                    <td>1</td>
+                    <td>Mercedes</td>
+                    <td>539</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
- La sección del titulo es un hero, está centrado y entra correctamente en la pantalla
- Antes de la tabla hay un menú de pestañas correspondientes a cada tabla
- Las tablas de resultados se ajustan al tamaño de la pantalla